### PR TITLE
castislogger에 severity 골라서 로그 파일을 따로 만들 수 있는 기능 추가, cichannellogger.h, cihttpaccesslogger.h 추가

### DIFF
--- a/examples/example_async.cpp
+++ b/examples/example_async.cpp
@@ -2,7 +2,10 @@
 
 int main() {
   auto sink = castis::logger::init_async_logger("example", "1.0.0");
-
+  auto sink_hour = castis::logger::init_async_date_hour_logger("example_hour", "1.0.0");
+  auto sink_hour_level_sink = castis::logger::init_async_date_hour_level_logger(
+    "example", "1.0.0", {error, exception}, "error_exception");
+  
   // support severity levels
   CILOG(foo) << "Just a foo";
   CILOG(debug) << "A normal severity message";
@@ -26,6 +29,8 @@ int main() {
   }
 
   castis::logger::stop_logger(sink);
+  castis::logger::stop_logger(sink_hour);
+  castis::logger::stop_logger(sink_hour_level_sink);
 
   return 0;
 }

--- a/logger/cichannellogger.h
+++ b/logger/cichannellogger.h
@@ -1,0 +1,596 @@
+#pragma once
+#include <boost/log/sources/severity_channel_logger.hpp>
+#include <boost/log/expressions/formatters/csv_decorator.hpp>
+#include <boost/log/expressions/formatters/named_scope.hpp>
+#include <boost/log/attributes/named_scope.hpp>
+#include "boost/date_time/posix_time/posix_time.hpp" 
+#include "castislogger.h"
+
+// cichannellogger.h
+//
+// almost logic come from castislogger.h
+//
+
+BOOST_LOG_INLINE_GLOBAL_LOGGER_DEFAULT(
+    ChanelLogger,
+    boost::log::sources::severity_channel_logger_mt<severity_level>)
+
+#define CILOG_CHANNEL(channel_name, severity)                                      \
+  BOOST_LOG_FUNCTION() \
+  BOOST_LOG_CHANNEL_SEV(ChanelLogger::get(), channel_name, severity) \
+
+#define CILOGF_CHANNEL(channel_name, severity, format, ...)                        \
+  BOOST_LOG_FUNCTION() \
+  BOOST_LOG_CHANNEL_SEV(ChanelLogger::get(), channel_name, severity) \
+  << castis::logger::formatter(format, ##__VA_ARGS__)
+
+// cilog_size_based_backup_backend :
+//
+// almost logics come from cilog_backend
+//
+// log file name example:
+// active log file : 
+// example.log
+// backup log file : 
+// 2018-10/2018-10-12[0]_example.log
+// 2018-10/2018-10-12[1]_example.log
+//
+// WARN : crash when log path set to current directory {"."}. 
+// fiexed : Fix #12495 BOOST-1.68.0
+
+class cilog_date_hour_based_backup_backend
+    : public boost::log::sinks::basic_formatted_sink_backend<
+    char, boost::log::sinks::synchronized_feeding> {
+ private:
+  bool auto_flush_;
+  boost::filesystem::ofstream file_;
+  boost::filesystem::path target_path_;
+  boost::filesystem::path file_path_;
+  std::string file_name_suffix_;
+  std::string current_date_hour_;
+  std::string file_name_prefix_format_;
+
+ public:
+  explicit cilog_date_hour_based_backup_backend(
+      boost::filesystem::path const& target_path,
+      std::string const& file_name_suffix,
+      std::string const& file_name_prefix_format, 
+      bool auto_flush)
+      : 
+      target_path_(target_path),
+      file_name_suffix_(file_name_suffix),
+      file_name_prefix_format_(file_name_prefix_format),
+      auto_flush_(auto_flush),
+      current_date_hour_(get_current_date_hour()){
+  }
+
+  void consume(
+      boost::log::record_view const& /*rec*/,
+      std::basic_string<char> const& formatted_message) {
+
+    if (current_date_hour_ != get_current_date_hour()) {
+      file_path_ = generate_active_filepath();
+      rotate_file();
+    }
+
+    if (!file_.is_open()) {
+      file_path_ = generate_active_filepath();
+      boost::filesystem::create_directories(file_path_.parent_path());
+      file_.open(file_path_, std::ofstream::out | std::ofstream::app);
+      if (!file_.is_open()) {
+        // failed to open file
+        return;
+      }
+    }
+    file_.write(
+        formatted_message.data(),
+        static_cast<std::streamsize>(formatted_message.size()));
+    file_.put('\n');
+
+    if (auto_flush_) file_.flush();
+
+    if (current_date_hour_ != get_current_date_hour()) {
+      rotate_file();
+    }
+  }
+
+private:
+  void rotate_file() {
+    if (file_.is_open()) {
+      file_.close();
+      file_.clear();
+    }
+    rollover_without_max();
+    current_date_hour_ = get_current_date_hour();
+  }
+  
+  boost::filesystem::path generate_active_filepath() {
+    // e.g. example.log
+    std::stringstream filename_ss;
+    filename_ss << file_name_suffix_;
+    filename_ss << ".log";
+
+    return boost::filesystem::path(target_path_ / filename_ss.str());
+  }
+  
+  void rollover_without_max() {
+
+    try {
+    boost::filesystem::path backup_file_path = generate_filepath();
+    boost::filesystem::create_directories(backup_file_path.parent_path());
+    boost::filesystem::rename(file_path_, backup_file_path);
+    } catch(boost::filesystem::filesystem_error& ) {}
+  }
+
+  boost::filesystem::path generate_filepath() {
+    if (file_name_prefix_format_.empty()) file_name_prefix_format_ = "%Y-%m-%d[%H]";
+    std::string filename_prefix = datetime_string_with_format(file_name_prefix_format_, -1);
+    std::string monthly_path_name = datetime_string_with_format("%Y-%m", -1);
+
+    boost::filesystem::path monthly_path(target_path_ / monthly_path_name);
+
+    // e.g. 2014-08-12[1]_example.log
+    std::stringstream filename_ss;
+    filename_ss << filename_prefix;
+    filename_ss << "_" + file_name_suffix_;
+    filename_ss << ".log";
+
+    return boost::filesystem::path(monthly_path / filename_ss.str());
+  }
+
+  std::string datetime_string_with_format(std::string const& format, int hour) {
+    std::locale loc(
+        std::cout.getloc(),
+        new boost::posix_time::time_facet(format.c_str()));
+    std::stringstream ss;
+    ss.imbue(loc);
+    ss << boost::posix_time::second_clock::local_time() + boost::posix_time::hours(hour);
+
+    return ss.str();
+  }
+  std::string get_current_date_hour() {
+    return datetime_string_with_format("%Y-%m-%d %H", 0);
+  }
+
+};
+
+class cilog_size_based_backup_backend
+    : public boost::log::sinks::basic_formatted_sink_backend<
+    char, boost::log::sinks::synchronized_feeding> {
+ private:
+  bool auto_flush_;
+  boost::filesystem::ofstream file_;
+  boost::filesystem::path target_path_;
+  boost::filesystem::path file_path_;
+  std::string file_name_suffix_;
+  uintmax_t rotation_size_;
+  uintmax_t characters_written_;
+  boost::gregorian::date current_date_;
+
+ public:
+  explicit cilog_size_based_backup_backend(
+      boost::filesystem::path const& target_path,
+      std::string const& file_name_suffix, uintmax_t rotation_size,
+      bool auto_flush)
+      : auto_flush_(auto_flush),
+        target_path_(target_path),
+        file_name_suffix_(file_name_suffix),
+        rotation_size_(rotation_size),
+        characters_written_(0),
+        current_date_(boost::gregorian::day_clock::local_day()) {}
+
+  void consume(boost::log::record_view const& /*rec*/,
+               std::basic_string<char> const& formatted_message) {
+    if (current_date_ != boost::gregorian::day_clock::local_day()) {
+      file_path_ = generate_active_filepath();
+      rotate_file();
+    }
+
+    if (!file_.is_open()) {
+      file_path_ = generate_active_filepath();
+      boost::filesystem::create_directories(file_path_.parent_path());
+      file_.open(file_path_, std::ofstream::out | std::ofstream::app);
+      if (!file_.is_open()) {
+        // failed to open file
+        return;
+      }
+      characters_written_ = static_cast<std::streamoff>(file_.tellp());
+    }
+    file_.write(formatted_message.data(),
+                static_cast<std::streamsize>(formatted_message.size()));
+    file_.put('\n');
+    characters_written_ += formatted_message.size() + 1;
+
+    if (auto_flush_) file_.flush();
+
+    if (characters_written_ >= rotation_size_) {
+      rotate_file();
+    }
+  }
+
+ private:
+  void rotate_file() {
+    if (file_.is_open()) {
+      file_.close();
+      file_.clear();
+    }
+    characters_written_ = 0;
+    // create backup files
+    rollover_without_max();
+    current_date_ = boost::gregorian::day_clock::local_day();
+  }
+
+  boost::filesystem::path generate_active_filepath() {
+    // e.g. example.log
+    std::stringstream filename_ss;
+    filename_ss << file_name_suffix_;
+    filename_ss << ".log";
+
+    return boost::filesystem::path(target_path_ / filename_ss.str());
+  }
+
+  void rollover_without_max() {
+    try {
+    boost::filesystem::path backup_file_path = generate_filepath();
+    boost::filesystem::create_directories(backup_file_path.parent_path());
+    boost::filesystem::rename(file_path_, backup_file_path);
+    } catch(boost::filesystem::filesystem_error&) {}
+  }
+
+  boost::filesystem::path generate_filepath() {
+    std::string filename_prefix = datetime_string_with_format("%Y-%m-%d");
+    std::string monthly_path_name = datetime_string_with_format("%Y-%m");
+
+    boost::filesystem::path monthly_path(target_path_ / monthly_path_name);
+    boost::regex pattern(filename_prefix + "(\\[[0-9]+\\])?" + "_" +
+                         file_name_suffix_ + ".log");
+    uintmax_t next_index = scan_next_index(monthly_path, pattern);
+
+    std::stringstream filename_ss;
+    filename_ss << filename_prefix;
+
+    filename_ss << "[" << next_index << "]";
+    filename_ss << "_" + file_name_suffix_;
+    filename_ss << ".log";
+
+    return boost::filesystem::path(monthly_path / filename_ss.str());
+  }
+
+  std::string datetime_string_with_format(std::string const& format) {
+    std::locale loc(std::cout.getloc(),
+                    new boost::posix_time::time_facet(format.c_str()));
+    std::stringstream ss;
+    ss.imbue(loc);
+    ss << boost::posix_time::second_clock::local_time();
+    return ss.str();
+  }
+
+  uintmax_t scan_next_index(boost::filesystem::path const& path,
+                            boost::regex const& pattern) {
+    uintmax_t current_index = 0;
+    boost::filesystem::path current_fs;
+    if (boost::filesystem::exists(path) &&
+        boost::filesystem::is_directory(path)) {
+      boost::filesystem::directory_iterator it(path), end;
+      for (; it != end; ++it) {
+        if (boost::regex_match(it->path().filename().string(), pattern)) {
+          uintmax_t index = parse_index(it->path().filename().string());
+          if (index >= current_index) {
+            current_index = index;
+            current_fs = it->path();
+          }
+        }
+      }
+    }
+    boost::system::error_code ec;
+    uintmax_t filesize = boost::filesystem::file_size(current_fs, ec);
+    if (!ec) {
+      if (filesize >= rotation_size_) {
+        ++current_index;
+      }
+    }
+    return current_index;
+  }
+
+  uintmax_t parse_index(std::string const& filename) {
+    size_t pos_index_begin = filename.find('[');
+    size_t pos_index_end = filename.find(']');
+    unsigned int index = 0;
+    if (pos_index_begin != std::string::npos &&
+        pos_index_end != std::string::npos) {
+      index = atoi(
+          filename.substr(pos_index_begin + 1, pos_index_end - pos_index_begin)
+              .c_str());
+    }
+    return index;
+  }
+};
+
+namespace castis {
+namespace logger {
+
+typedef boost::log::sinks::asynchronous_sink<cilog_size_based_backup_backend>
+    cichannellog_async_sink;
+typedef boost::log::sinks::asynchronous_sink<cilog_date_hour_based_backup_backend>
+    cichannellog_date_hour_async_sink;    
+
+inline boost::shared_ptr<cichannellog_async_sink>
+init_async_channel_logger(const std::string& app_name,
+                         const std::string& app_version,
+                         const std::string& channel_name, 
+                         const std::string& target = "./log",
+                         int64_t rotation_size = 100 * 100 * 1024,
+                         bool with_func_scope = false, 
+                         bool csv_format = true,
+                         bool auto_flush = true) {
+  namespace expr = boost::log::expressions;
+  boost::log::add_common_attributes();
+  boost::shared_ptr<cilog_size_based_backup_backend> backend(
+      new cilog_size_based_backup_backend(
+          boost::filesystem::path(target), app_name, rotation_size,
+          auto_flush));
+
+  boost::shared_ptr<cichannellog_async_sink> sink(
+      new cichannellog_async_sink(backend));
+
+  std::string fs="%F::%C:%l";
+  if (with_func_scope) fs="%F::%c:%l";
+  if (csv_format) {
+    sink->set_formatter(expr::stream
+                        << app_name << "," << app_version << ","
+                        << expr::format_date_time<boost::posix_time::ptime>(
+                              "TimeStamp", "%Y-%m-%d,%H:%M:%S.%f")
+                        << ","
+                        << expr::attr<severity_level, severity_tag>("Severity")
+                        << "," << "\"" 
+                        << expr::csv_decor[ expr::stream << expr::format_named_scope("Scopes", 
+                                                    boost::log::keywords::format = fs,
+                                                    boost::log::keywords::depth = 1,
+                                                    boost::log::keywords::incomplete_marker=""
+                                                    )]
+                        << "\"" 
+                        << ",," << "\"" 
+                        << expr::csv_decor[ expr::stream << expr::smessage  ]
+                        << "\"" 
+                        );
+  } else {
+    sink->set_formatter(expr::stream
+                        << app_name << "," << app_version << ","
+                        << expr::format_date_time<boost::posix_time::ptime>(
+                              "TimeStamp", "%Y-%m-%d,%H:%M:%S.%f")
+                        << ","
+                        << expr::attr<severity_level, severity_tag>("Severity")
+                        << ","
+                        << expr::format_named_scope("Scopes", 
+                                                    boost::log::keywords::format = fs,
+                                                    boost::log::keywords::depth = 1,
+                                                    boost::log::keywords::incomplete_marker=""
+                                                   )
+                        << ",," << expr::smessage 
+                        );
+  }
+
+  sink->set_filter(expr::attr<std::string>("Channel") == channel_name);
+
+  boost::log::core::get()->add_global_attribute("Scopes", boost::log::attributes::named_scope());
+  boost::log::core::get()->add_sink(sink);
+  return sink;
+}
+
+inline void stop_logger(boost::shared_ptr<cichannellog_async_sink>& async_sink) {
+  boost::shared_ptr<boost::log::core> core = boost::log::core::get();
+  core->remove_sink(async_sink);
+  async_sink->stop();
+  async_sink->flush();
+  async_sink.reset();
+}
+
+inline boost::shared_ptr<cichannellog_date_hour_async_sink>
+init_async_date_hour_channel_logger(const std::string& app_name,
+                         const std::string& app_version,
+                         const std::string& channel_name, 
+                         const std::string& target = "./log",
+                         const std::string& file_name_prefix_format="%Y-%m-%d[%H]",
+                         bool with_func_scope = false, 
+                         bool csv_format = true,
+                         bool auto_flush = true) {
+  namespace expr = boost::log::expressions;
+  boost::log::add_common_attributes();
+  boost::shared_ptr<cilog_date_hour_based_backup_backend> backend(
+      new cilog_date_hour_based_backup_backend(
+          boost::filesystem::path(target), app_name,file_name_prefix_format,  
+          auto_flush));
+
+  boost::shared_ptr<cichannellog_date_hour_async_sink> sink(
+      new cichannellog_date_hour_async_sink(backend));
+
+  std::string fs="%F::%C:%l";
+  if (with_func_scope) fs="%F::%c:%l";
+  if (csv_format) {
+    sink->set_formatter(expr::stream
+                        << app_name << "," << app_version << ","
+                        << expr::format_date_time<boost::posix_time::ptime>(
+                              "TimeStamp", "%Y-%m-%d,%H:%M:%S.%f")
+                        << ","
+                        << expr::attr<severity_level, severity_tag>("Severity")
+                        << "," << "\"" 
+                        << expr::csv_decor[ expr::stream << expr::format_named_scope("Scopes", 
+                                                    boost::log::keywords::format = fs,
+                                                    boost::log::keywords::depth = 1,
+                                                    boost::log::keywords::incomplete_marker=""
+                                                    )]
+                        << "\"" 
+                        << ",," << "\"" 
+                        << expr::csv_decor[ expr::stream << expr::smessage  ]
+                        << "\"" 
+                        );
+  } else {
+    sink->set_formatter(expr::stream
+                        << app_name << "," << app_version << ","
+                        << expr::format_date_time<boost::posix_time::ptime>(
+                              "TimeStamp", "%Y-%m-%d,%H:%M:%S.%f")
+                        << ","
+                        << expr::attr<severity_level, severity_tag>("Severity")
+                        << ","
+                        << expr::format_named_scope("Scopes", 
+                                                    boost::log::keywords::format = fs,
+                                                    boost::log::keywords::depth = 1,
+                                                    boost::log::keywords::incomplete_marker=""
+                                                   )
+                        << ",," << expr::smessage 
+                        );
+  }
+
+  sink->set_filter(expr::attr<std::string>("Channel") == channel_name);
+
+  boost::log::core::get()->add_global_attribute("Scopes", boost::log::attributes::named_scope());
+  boost::log::core::get()->add_sink(sink);
+  return sink;
+}
+
+inline boost::shared_ptr<cichannellog_async_sink>
+init_async_channel_level_logger(const std::string& app_name,
+                         const std::string& app_version,
+                         const std::string& channel_name,
+                         const std::vector<severity_level> severity_levels,
+                         const std::string& file_name_suffix, 
+                         const std::string& target = "./log",
+                         int64_t rotation_size = 100 * 100 * 1024,
+                         bool with_func_scope = false, 
+                         bool csv_format = true,
+                         bool auto_flush = true) {
+  namespace expr = boost::log::expressions;
+  boost::log::add_common_attributes();
+  boost::shared_ptr<cilog_size_based_backup_backend> backend(
+      new cilog_size_based_backup_backend(
+          boost::filesystem::path(target), file_name_suffix, rotation_size,
+          auto_flush));
+
+  boost::shared_ptr<cichannellog_async_sink> sink(
+      new cichannellog_async_sink(backend));
+
+  std::string fs="%F::%C:%l";
+  if (with_func_scope) fs="%F::%c:%l";
+  if (csv_format) {
+    sink->set_formatter(expr::stream
+                        << app_name << "," << app_version << ","
+                        << expr::format_date_time<boost::posix_time::ptime>(
+                              "TimeStamp", "%Y-%m-%d,%H:%M:%S.%f")
+                        << ","
+                        << expr::attr<severity_level, severity_tag>("Severity")
+                        << "," << "\"" 
+                        << expr::csv_decor[ expr::stream << expr::format_named_scope("Scopes", 
+                                                    boost::log::keywords::format = fs,
+                                                    boost::log::keywords::depth = 1,
+                                                    boost::log::keywords::incomplete_marker=""
+                                                    )]
+                        << "\"" 
+                        << ",," << "\"" 
+                        << expr::csv_decor[ expr::stream << expr::smessage  ]
+                        << "\"" 
+                        );
+  } else {
+    sink->set_formatter(expr::stream
+                        << app_name << "," << app_version << ","
+                        << expr::format_date_time<boost::posix_time::ptime>(
+                              "TimeStamp", "%Y-%m-%d,%H:%M:%S.%f")
+                        << ","
+                        << expr::attr<severity_level, severity_tag>("Severity")
+                        << ","
+                        << expr::format_named_scope("Scopes", 
+                                                    boost::log::keywords::format = fs,
+                                                    boost::log::keywords::depth = 1,
+                                                    boost::log::keywords::incomplete_marker=""
+                                                   )
+                        << ",," << expr::smessage 
+                        );
+  }
+
+  sink->set_filter(
+    expr::attr<std::string>("Channel") == channel_name &&
+    boost::phoenix::bind(&func_severity_filter, expr::attr<severity_level>("Severity"), severity_levels)
+  );
+
+  boost::log::core::get()->add_global_attribute("Scopes", boost::log::attributes::named_scope());
+  boost::log::core::get()->add_sink(sink);
+  return sink;
+}
+
+inline boost::shared_ptr<cichannellog_date_hour_async_sink>
+init_async_date_hour_channel_level_logger(const std::string& app_name,
+                         const std::string& app_version,
+                         const std::string& channel_name, 
+                         const std::vector<severity_level> severity_levels,
+                         const std::string& file_name_suffix,
+                         const std::string& target = "./log",
+                         const std::string& file_name_prefix_format="%Y-%m-%d[%H]",
+                         bool with_func_scope = false, 
+                         bool csv_format = true,
+                         bool auto_flush = true) {
+  namespace expr = boost::log::expressions;
+  boost::log::add_common_attributes();
+  boost::shared_ptr<cilog_date_hour_based_backup_backend> backend(
+      new cilog_date_hour_based_backup_backend(
+          boost::filesystem::path(target), file_name_suffix, file_name_prefix_format,  
+          auto_flush));
+
+  boost::shared_ptr<cichannellog_date_hour_async_sink> sink(
+      new cichannellog_date_hour_async_sink(backend));
+
+  std::string fs="%F::%C:%l";
+  if (with_func_scope) fs="%F::%c:%l";
+  if (csv_format) {
+    sink->set_formatter(expr::stream
+                        << app_name << "," << app_version << ","
+                        << expr::format_date_time<boost::posix_time::ptime>(
+                              "TimeStamp", "%Y-%m-%d,%H:%M:%S.%f")
+                        << ","
+                        << expr::attr<severity_level, severity_tag>("Severity")
+                        << "," << "\"" 
+                        << expr::csv_decor[ expr::stream << expr::format_named_scope("Scopes", 
+                                                    boost::log::keywords::format = fs,
+                                                    boost::log::keywords::depth = 1,
+                                                    boost::log::keywords::incomplete_marker=""
+                                                    )]
+                        << "\"" 
+                        << ",," << "\"" 
+                        << expr::csv_decor[ expr::stream << expr::smessage  ]
+                        << "\"" 
+                        );
+  } else {
+    sink->set_formatter(expr::stream
+                        << app_name << "," << app_version << ","
+                        << expr::format_date_time<boost::posix_time::ptime>(
+                              "TimeStamp", "%Y-%m-%d,%H:%M:%S.%f")
+                        << ","
+                        << expr::attr<severity_level, severity_tag>("Severity")
+                        << ","
+                        << expr::format_named_scope("Scopes", 
+                                                    boost::log::keywords::format = fs,
+                                                    boost::log::keywords::depth = 1,
+                                                    boost::log::keywords::incomplete_marker=""
+                                                   )
+                        << ",," << expr::smessage 
+                        );
+  }
+
+  sink->set_filter(
+    expr::attr<std::string>("Channel") == channel_name &&
+    boost::phoenix::bind(&func_severity_filter, expr::attr<severity_level>("Severity"), severity_levels)
+  );
+
+  boost::log::core::get()->add_global_attribute("Scopes", boost::log::attributes::named_scope());
+  boost::log::core::get()->add_sink(sink);
+  return sink;
+}
+
+inline void stop_logger(boost::shared_ptr<cichannellog_date_hour_async_sink>& async_sink) {
+  boost::shared_ptr<boost::log::core> core = boost::log::core::get();
+  core->remove_sink(async_sink);
+  async_sink->stop();
+  async_sink->flush();
+  async_sink.reset();
+}
+
+} // logger 
+} // castis

--- a/logger/cihttpaccesslogger.h
+++ b/logger/cihttpaccesslogger.h
@@ -1,0 +1,158 @@
+#pragma once
+
+#include <chrono>
+#include <ctime>  
+#include <iostream>
+#include "cichannellogger.h"
+#include <boost/log/utility/manipulators/add_value.hpp>
+
+
+#define HTTPACCESSLOG(http_access) \
+  BOOST_LOG_CHANNEL_SEV(ChanelLogger::get(), "ACCESS", info)  \
+  << boost::log::add_value("remoteAddress", http_access.remote_addr) \
+  << boost::log::add_value("remoteIdent", http_access.remote_ident) \
+  << boost::log::add_value("userName", http_access.user_name) \
+  << boost::log::add_value("requestTime", http_access.request_time) \
+  << boost::log::add_value("requestLine", http_access.request_line) \
+  << boost::log::add_value("status", static_cast<unsigned>(http_access.status)) \
+  << boost::log::add_value("contentLength", static_cast<std::size_t>(http_access.content_length)) \
+  << boost::log::add_value("referer", http_access.referer) \
+  << boost::log::add_value("userAgent", http_access.user_agent) \
+
+struct cihttpaccesslog_attr_tag;
+
+namespace castis {
+namespace logger {
+
+namespace httpaccesslog {
+
+  const std::string kDelimiter = " ";
+  const std::string kQuotes = "\"";
+  const std::string kEmpty = "-";
+
+  static std::string request_line(const std::string& method, const std::string& uri, unsigned version_major=1, unsigned version_minor=1) {
+    return method + httpaccesslog::kDelimiter + uri + httpaccesslog::kDelimiter + "HTTP/" + std::to_string(version_major)+"."+std::to_string(version_minor);
+  }
+  static std::string request_time() {
+    std::time_t req_t = std::time(nullptr);
+    std::string request_time_str = httpaccesslog::kEmpty;
+    char mbstr[256];
+    if (std::strftime(mbstr, sizeof(mbstr), "[%d/%b/%Y:%H:%M:%S %z]",
+                      std::localtime(&req_t)) > 0) {
+      request_time_str = mbstr;
+    }
+    return request_time_str;
+  }
+}
+
+struct HttpAccess { // https://developer.mozilla.org/ko/docs/Web/HTTP
+  std::string remote_addr;   // Remote client ip
+  std::string remote_ident;  // REMOTE_IDENT : The remote logname, user id
+  std::string user_name;     // The name of the authenticated remote user
+  std::string request_time;      // Request time : Date and time of the request.
+  std::string request_line;  // The first line of the request. Example: GET / HTTP/1.0
+  unsigned status;       // Final status code of http response
+  std::size_t content_length;     // Content-Length of http response
+  std::string referer;      // Referer of http req header 
+  std::string user_agent;    // User-Agent of http req heder
+ 
+  // [:data] foramt -> [05/Sep/2018:16:48:09 +0900]
+  // ':remote-addr - - [:date] ":method :uri HTTP/:http-version" :status
+  // :res[content-length] ":referrer" ":user-agent"'
+  std::string to_string() const {
+    namespace alog = castis::logger::httpaccesslog;
+    const HttpAccess& http_access = *this;
+    std::string str = (http_access.remote_addr.empty() ? alog::kEmpty : http_access.remote_addr) + alog::kDelimiter
+        + (http_access.remote_ident.empty() ? alog::kEmpty : http_access.remote_ident) + alog::kDelimiter
+        + (http_access.user_name.empty() ? alog::kEmpty : http_access.user_name) + alog::kDelimiter
+        + (http_access.request_time.empty() ? alog::kEmpty : http_access.request_time) + alog::kDelimiter 
+        + alog::kQuotes + (http_access.request_line.empty() ? alog::kEmpty : http_access.request_line) + alog::kQuotes + alog::kDelimiter
+        + ((http_access.status <= 0)  ? alog::kEmpty : std::to_string(http_access.status)) + alog::kDelimiter 
+        + ((http_access.content_length <= 0)  ? alog::kEmpty : std::to_string(http_access.content_length)) + alog::kDelimiter
+        + alog::kQuotes + (http_access.referer.empty() ? alog::kEmpty : http_access.referer) + alog::kQuotes + alog::kDelimiter
+        + alog::kQuotes + (http_access.user_agent.empty() ? alog::kEmpty : http_access.user_agent) + alog::kQuotes ;
+    return str;
+  }
+
+  friend std::ostream& operator<<(std::ostream& os,
+                                  const HttpAccess& http_access);
+};
+
+inline std::ostream& operator<<(std::ostream& strm, const HttpAccess& http_access) {
+  strm << http_access.to_string();
+  return strm;
+}
+
+}  // namespace logger
+}  // namespace castis
+
+inline boost::log::formatting_ostream& operator<< (
+    boost::log::formatting_ostream& strm,
+    boost::log::to_log_manip<unsigned, cihttpaccesslog_attr_tag> const& manip) {
+  namespace alog = castis::logger::httpaccesslog;
+  unsigned value = manip.get();
+  if (value <= 0 )
+    strm << alog::kEmpty;
+  else
+    strm << value;
+  return strm;
+}
+inline boost::log::formatting_ostream& operator<< (
+    boost::log::formatting_ostream& strm,
+    boost::log::to_log_manip<std::size_t, cihttpaccesslog_attr_tag> const& manip) {
+  namespace alog = castis::logger::httpaccesslog;
+  std::size_t value = manip.get();
+  if (value <= 0 )
+    strm << alog::kEmpty;
+  else
+    strm << value;
+  return strm;
+}
+
+inline boost::log::formatting_ostream& operator<< (
+    boost::log::formatting_ostream& strm,
+    boost::log::to_log_manip<std::string, cihttpaccesslog_attr_tag> const& manip) {
+  namespace alog = castis::logger::httpaccesslog;
+  std::string value = manip.get();
+  if (value.empty())
+    strm << alog::kEmpty;
+  else
+    strm << value;
+  return strm;
+}
+
+namespace castis {
+namespace logger {
+
+inline boost::shared_ptr<cichannellog_async_sink>
+init_httpaccess_logger(const std::string& file_name,
+                                const std::string& target = "./log",
+                                int64_t rotation_size = 100 * 100 * 1024) {
+  namespace expr = boost::log::expressions;
+  boost::log::add_common_attributes();
+  boost::shared_ptr<cilog_size_based_backup_backend> backend(
+      new cilog_size_based_backup_backend(
+          boost::filesystem::path(target), file_name, rotation_size,true));
+
+  boost::shared_ptr<cichannellog_async_sink> sink(
+      new cichannellog_async_sink(backend));
+
+  sink->set_formatter(expr::stream
+                    << expr::attr<std::string, cihttpaccesslog_attr_tag>("remoteAddress") << httpaccesslog::kDelimiter
+                    << expr::attr<std::string, cihttpaccesslog_attr_tag>("remoteIdent") << httpaccesslog::kDelimiter
+                    << expr::attr<std::string, cihttpaccesslog_attr_tag>("userName") << httpaccesslog::kDelimiter
+                    << expr::attr<std::string, cihttpaccesslog_attr_tag>("requestTime") << httpaccesslog::kDelimiter
+                    << httpaccesslog::kQuotes << expr::attr<std::string, cihttpaccesslog_attr_tag>("requestLine") << httpaccesslog::kQuotes << httpaccesslog::kDelimiter
+                    << expr::attr<unsigned, cihttpaccesslog_attr_tag>("status") << httpaccesslog::kDelimiter
+                    << expr::attr<std::size_t, cihttpaccesslog_attr_tag>("contentLength") << httpaccesslog::kDelimiter
+                    << httpaccesslog::kQuotes << expr::attr<std::string, cihttpaccesslog_attr_tag>("referer") << httpaccesslog::kQuotes << httpaccesslog::kDelimiter
+                    << httpaccesslog::kQuotes << expr::attr<std::string, cihttpaccesslog_attr_tag>("userAgent") << httpaccesslog::kQuotes 
+                    );
+
+  sink->set_filter(expr::attr<std::string>("Channel") == "ACCESS");
+  boost::log::core::get()->add_sink(sink);
+  return sink;
+}
+}
+}
+ 


### PR DESCRIPTION
- castislogger.h
  - 선택한 severity의 로그만 기록하는 logger 추가
- cichannellogger.h 추가
  - channel 속성이 있는 로그를 사용하는 logger 추가
- cihttpaccesslogger.h 추가
  - Appache access logger 형태로 기록하는 logger 추가